### PR TITLE
Await page load and disable timeout

### DIFF
--- a/remarkjs-pdf.js
+++ b/remarkjs-pdf.js
@@ -77,7 +77,7 @@ async function main() {
 }
 async function convertPdf(browser, {html, pdf, name, size}) {
   const page = await browser.newPage();
-  await page.goto(html);
+  await page.goto(html, {waitUntil: 'load', timeout: 0});
 
   // 1. check remark.js slideshow features
   const notFound = await page.evaluate(ss => {


### PR DESCRIPTION
Add option to wait for page load and disable timeout to prevent errors when loading heavy page.

Error :

```
TimeoutError: Navigation timeout of 30000 ms exceeded
    at /opt/hostedtoolcache/node/12.13.1/x64/lib/node_modules/remarkjs-pdf/node_modules/puppeteer/lib/LifecycleWatcher.js:142:21
  -- ASYNC --
    at Frame.<anonymous> (/opt/hostedtoolcache/node/12.13.1/x64/lib/node_modules/remarkjs-pdf/node_modules/puppeteer/lib/helper.js:111:15)
    at Page.goto (/opt/hostedtoolcache/node/12.13.1/x64/lib/node_modules/remarkjs-pdf/node_modules/puppeteer/lib/Page.js:675:49)
    at Page.<anonymous> (/opt/hostedtoolcache/node/12.13.1/x64/lib/node_modules/remarkjs-pdf/node_modules/puppeteer/lib/helper.js:112:23)
    at convertPdf (/opt/hostedtoolcache/node/12.13.1/x64/lib/node_modules/remarkjs-pdf/remarkjs-pdf.js:80:14)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async main (/opt/hostedtoolcache/node/12.13.1/x64/lib/node_modules/remarkjs-pdf/remarkjs-pdf.js:69:5) {
  name: 'TimeoutError'
```